### PR TITLE
Quick spike on refactoring connection keyspace tracking.

### DIFF
--- a/lib/cql/io/io_reactor.rb
+++ b/lib/cql/io/io_reactor.rb
@@ -91,6 +91,10 @@ module Cql
         f
       end
 
+      def connections
+        @connections[1..-1]
+      end
+
       # Sends a request over a random, or specific connection.
       #
       # @param [Cql::Protocol::RequestBody] request the request to send


### PR DESCRIPTION
This branch is just a quick experiment, and it's not ready for merging as-is, but I wanted to get your response to the basic idea.

This change alone doesn't dramatically improve the code, but critically, it moves detailed knowledge of the current connections out of the client. Doing that makes it much simpler to implement reconnection and automatic connection discovery, which is my ultimate goal.

If you are okay with the approach, I'll update this branch with full comments and tests.
