### PR TITLE
Expose async api

### DIFF
--- a/lib/cql/client.rb
+++ b/lib/cql/client.rb
@@ -179,7 +179,6 @@ module Cql
     #   (see {QueryResult}).
     #
     def execute(cql, consistency=DEFAULT_CONSISTENCY_LEVEL)
-      logger.info(cql)
       execute_async(cql,consistency).value
     end
 


### PR DESCRIPTION
Just a naive attempt to expose the future api to user

The spec sometimes freezes at

```
#add_event_listener
    calls the listener when frames with stream ID -1 arrives
  with error conditions
    when receiving a bad frame
      does not kill the reactor
```
