### PR TITLE
Modified KEYSPACE_NAME_PATTERN to allow for quoted keyspaces.

### DIFF
--- a/lib/cql/client/asynchronous_client.rb
+++ b/lib/cql/client/asynchronous_client.rb
@@ -108,7 +108,7 @@ module Cql
 
       private
 
-      KEYSPACE_NAME_PATTERN = /^\w[\w\d_]*$/
+      KEYSPACE_NAME_PATTERN = /^\w[\w\d_]*$|^"\w[\w\d_]*"$/
       DEFAULT_CONSISTENCY_LEVEL = :quorum
 
       class FailedConnection

--- a/spec/cql/client/asynchronous_client_spec.rb
+++ b/spec/cql/client/asynchronous_client_spec.rb
@@ -408,6 +408,17 @@ module Cql
           client.connect.get
           expect { client.use('system; DROP KEYSPACE system').get }.to raise_error(InvalidKeyspaceNameError)
         end
+
+        it 'allows quoted keyspace' do
+          handle_request do |request|
+            if request.is_a?(Protocol::QueryRequest) && request.cql == 'USE "system"'
+              Protocol::SetKeyspaceResultResponse.new('system')
+            end
+          end
+          client.connect.get
+          client.use('"system"').get
+          client.keyspace.should == "system"
+        end
       end
 
       describe '#execute' do


### PR DESCRIPTION
This fixes the issue I filed today (https://github.com/iconara/cql-rb/issues/28) and allows people to use keyspaces that contain capital letters.
