### PR TITLE
Cql::Uuid#eql? fails when a non-UUID is compared

### DIFF
--- a/lib/cql/uuid.rb
+++ b/lib/cql/uuid.rb
@@ -52,7 +52,7 @@ module Cql
 
     # @private
     def eql?(other)
-      self.value == other.value
+      other.kind_of?(Uuid) && self.value == other.value
     end
     alias_method :==, :eql?
 

--- a/spec/cql/uuid_spec.rb
+++ b/spec/cql/uuid_spec.rb
@@ -36,6 +36,10 @@ module Cql
         Uuid.new(276263553384940695775376958868900023510).should eql(Uuid.new('cfd66ccc-d857-4e90-b1e5-df98a3d40cd6'))
       end
 
+      it 'is not equal when anything other than a Uuid is passed' do
+        [nil, 123, 'test'].each { |v| Uuid.new(276263553384940695775376958868900023510).should_not eql(v) }
+      end
+
       it 'aliases #== to #eql?' do
         Uuid.new(276263553384940695775376958868900023510).should == Uuid.new('cfd66ccc-d857-4e90-b1e5-df98a3d40cd6')
       end


### PR DESCRIPTION
Currently if you attempt to compare a Cql::Uuid with most other classes, it will fail with the following:

```
NoMethodError: undefined method `value' for ...
```

This is because the `eql?` method blindly calls `#value` on the object being compared.

This PR fixes the issue by returning false if the object being compared is not a Cql::Uuid or descendant.
