### PR TITLE
Make Cql::Uuid behave more like SimpleUUID::UUID

### DIFF
--- a/lib/cql/uuid.rb
+++ b/lib/cql/uuid.rb
@@ -37,6 +37,7 @@ module Cql
         parts.join('-').force_encoding(::Encoding::ASCII)
       end
     end
+    alias_method :to_guid, :to_s
 
     def hash
       @h ||= 0x7fffffffffffffff - ((@n & 0xffffffffffffffff) ^ ((@n >> 64) & 0xffffffffffffffff))
@@ -49,6 +50,7 @@ module Cql
     def value
       @n
     end
+    alias_method :to_i, :value
 
     # @private
     def eql?(other)

--- a/spec/cql/uuid_spec.rb
+++ b/spec/cql/uuid_spec.rb
@@ -58,6 +58,12 @@ module Cql
       end
     end
 
+    describe '#to_guid' do
+      it 'returns a UUID standard format' do
+        Uuid.new('a4a70900-24e1-11df-8924-001ff3591711').to_guid.should == 'a4a70900-24e1-11df-8924-001ff3591711'
+      end
+    end
+
     describe '#hash' do
       it 'calculates a 64 bit hash of the UUID' do
         h = Uuid.new(162917432198567078063626261009205865234).hash
@@ -81,6 +87,12 @@ module Cql
     describe '#value' do
       it 'returns the numeric value' do
         Uuid.new('cfd66ccc-d857-4e90-b1e5-df98a3d40cd6').value.should == 276263553384940695775376958868900023510
+      end
+    end
+
+    describe '#to_i' do
+      it 'returns the numeric value' do
+        Uuid.new('cfd66ccc-d857-4e90-b1e5-df98a3d40cd6').to_i.should == 276263553384940695775376958868900023510
       end
     end
   end


### PR DESCRIPTION
One stumbling block when making the switch from `cassandra-cql` to `cql-rb` is 
the different UUID type returned from queries. This pull just adds a couple of 
method aliases to `Cql::Uuid` that makes it work with common use cases that 
were written around `SimpleUUID`:
- `to_guid` is an alias of `to_s`
- `to_i` is an alias of `value`
