### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ loop do
   result_page.each do |row|
     p row
   end
-  if result_page.last?
+  if result_page.last_page?
     break
   else
     result_page = result_page.next_page


### PR DESCRIPTION
`PagedQueryResult#last?` doesn't exist yet. We should use `PagedQueryResult#last_page?` instead. 

What about an alias for `#last?`.
