### PR TITLE
Allow UUIDs to be passed in as standard Hex-encoded strings.

### DIFF
--- a/lib/cql/protocol/encoding.rb
+++ b/lib/cql/protocol/encoding.rb
@@ -27,7 +27,7 @@ module Cql
       end
 
       def write_uuid(buffer, uuid)
-        v = uuid.value
+        v = uuid.class == String ? uuid.gsub(/-/,'').to_i(16) : uuid.value
         write_int(buffer, (v >> 96) & 0xffffffff)
         write_int(buffer, (v >> 64) & 0xffffffff)
         write_int(buffer, (v >> 32) & 0xffffffff)

--- a/spec/cql/protocol/encoding_spec.rb
+++ b/spec/cql/protocol/encoding_spec.rb
@@ -121,6 +121,11 @@ module Cql
           buffer.should eql_bytes("\xA4\xA7\t\x00$\xE1\x11\xDF\x89$\x00\x1F\xF3Y\x17\x11")
         end
 
+        it 'encodes an UUID that is passed in as a string' do
+          Encoding.write_uuid(buffer, uuid.to_s)
+          buffer.should eql_bytes("\xA4\xA7\t\x00$\xE1\x11\xDF\x89$\x00\x1F\xF3Y\x17\x11")
+        end
+
         it 'encodes a UUID as 16 bytes' do
           Encoding.write_uuid(buffer, Uuid.new('00000000-24e1-11df-8924-001ff3591711'))
           buffer.size.should eql(16)


### PR DESCRIPTION
This is a fairly simple change.  It simply looks to see if a uuid was passed in as a string and converts it to an integer value if so (for situations when it doesn't make sense to stand up a TimeUuid object just to pull the value out).
