### PR TITLE
Support client/node encryption

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 gem 'rake'
 gem 'snappy'
+gem 'ione', github: 'iconara/ione', branch: 'ssl_support'
 
 group :development do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git://github.com/iconara/ione.git
+  revision: f59c02b3b1368d24bc1d96ff3b4518f2f93aa56a
+  branch: ssl_support
+  specs:
+    ione (1.1.0)
+
 PATH
   remote: .
   specs:
@@ -16,7 +23,6 @@ GEM
       simplecov (>= 0.7)
       thor
     diff-lcs (1.2.4)
-    ione (1.0.0)
     method_source (0.8.1)
     mime-types (1.23)
     multi_json (1.7.7)
@@ -62,6 +68,7 @@ PLATFORMS
 DEPENDENCIES
   coveralls
   cql-rb!
+  ione!
   perftools.rb
   pry
   rake

--- a/lib/cql/client/client.rb
+++ b/lib/cql/client/client.rb
@@ -224,7 +224,9 @@ module Cql
         @connection_manager = ConnectionManager.new
         @execute_options_decoder = ExecuteOptionsDecoder.new(options[:default_consistency] || DEFAULT_CONSISTENCY)
         @port = options[:port] || DEFAULT_PORT
-        @connection_timeout = options[:connection_timeout] || DEFAULT_CONNECTION_TIMEOUT
+        @connection_options = {}
+        @connection_options[:timeout] = options[:connection_timeout] || DEFAULT_CONNECTION_TIMEOUT
+        @connection_options[:ssl] = options[:ssl] if options[:ssl]
         @credentials = options[:credentials]
         @auth_provider = options[:auth_provider] || @credentials && Auth::PlainTextAuthProvider.new(*@credentials.values_at(:username, :password))
         @connected = false
@@ -352,7 +354,7 @@ module Cql
         protocol_handler_factory = lambda { |connection| Protocol::CqlProtocolHandler.new(connection, @io_reactor, @protocol_version, @compressor) }
         ClusterConnector.new(
           Connector.new([
-            ConnectStep.new(@io_reactor, protocol_handler_factory, @port, @connection_timeout, @logger),
+            ConnectStep.new(@io_reactor, protocol_handler_factory, @port, @connection_options, @logger),
             CacheOptionsStep.new,
             InitializeStep.new(cql_version, @compressor, @logger),
             authentication_step,

--- a/lib/cql/client/connector.rb
+++ b/lib/cql/client/connector.rb
@@ -72,17 +72,17 @@ module Cql
 
     # @private
     class ConnectStep
-      def initialize(io_reactor, protocol_handler_factory, port, connection_timeout, logger)
+      def initialize(io_reactor, protocol_handler_factory, port, connection_options, logger)
         @io_reactor = io_reactor
         @protocol_handler_factory = protocol_handler_factory
         @port = port
-        @connection_timeout = connection_timeout
+        @connection_options = connection_options
         @logger = logger
       end
 
       def run(pending_connection)
         @logger.debug('Connecting to node at %s:%d' % [pending_connection.host, @port])
-        @io_reactor.connect(pending_connection.host, @port, @connection_timeout, &@protocol_handler_factory).map do |connection|
+        @io_reactor.connect(pending_connection.host, @port, @connection_options, &@protocol_handler_factory).map do |connection|
           pending_connection.with_connection(connection)
         end
       end

--- a/spec/cql/client/client_spec.rb
+++ b/spec/cql/client/client_spec.rb
@@ -361,6 +361,13 @@ module Cql
           last_connection.timeout.should == 10
         end
 
+        it 'enables client/node encryption when the :ssl option is set' do
+          ssl_context = double(:ssl_context)
+          client = described_class.new(connection_options.merge(ssl: ssl_context))
+          client.connect.value
+          last_connection.options.should include(ssl: ssl_context)
+        end
+
         it 'is not in a keyspace' do
           client.connect.value
           client.keyspace.should be_nil

--- a/spec/cql/client/connector_spec.rb
+++ b/spec/cql/client/connector_spec.rb
@@ -204,7 +204,11 @@ module Cql
 
     describe ConnectStep do
       let :step do
-        described_class.new(io_reactor, protocol_handler_factory, 1111, 9, logger)
+        described_class.new(io_reactor, protocol_handler_factory, 1111, connection_options, logger)
+      end
+
+      let :connection_options do
+        {:timeout => 8}
       end
 
       let :pending_connection do
@@ -246,7 +250,7 @@ module Cql
 
         it 'connects using the connection details given' do
           step.run(pending_connection)
-          io_reactor.should have_received(:connect).with('example.com', 1111, 9)
+          io_reactor.should have_received(:connect).with('example.com', 1111, connection_options)
         end
 
         it 'appends the connection to the given argument and returns the result' do

--- a/spec/cql/client/peer_discovery_spec.rb
+++ b/spec/cql/client/peer_discovery_spec.rb
@@ -13,9 +13,9 @@ module Cql
       describe '#new_hosts' do
         let :seed_connections do
           [
-            FakeConnection.new('host0', 9042, 5, {:data_center => 'dc0', :host_id => Uuid.new('00000000-0000-0000-0000-000000000000')}),
-            FakeConnection.new('host1', 9042, 5, {:data_center => 'dc0', :host_id => Uuid.new('11111111-1111-1111-1111-111111111111')}),
-            FakeConnection.new('host2', 9042, 5, {:data_center => 'dc0', :host_id => Uuid.new('22222222-2222-2222-2222-222222222222')}),
+            FakeConnection.new('host0', 9042, {}, {:data_center => 'dc0', :host_id => Uuid.new('00000000-0000-0000-0000-000000000000')}),
+            FakeConnection.new('host1', 9042, {}, {:data_center => 'dc0', :host_id => Uuid.new('11111111-1111-1111-1111-111111111111')}),
+            FakeConnection.new('host2', 9042, {}, {:data_center => 'dc0', :host_id => Uuid.new('22222222-2222-2222-2222-222222222222')}),
           ]
         end
 

--- a/spec/cql/client/prepared_statement_spec.rb
+++ b/spec/cql/client/prepared_statement_spec.rb
@@ -55,9 +55,9 @@ module Cql
 
       let :connections do
         [
-          FakeConnection.new('h0.example.com', 1234, 42),
-          FakeConnection.new('h1.example.com', 1234, 42),
-          FakeConnection.new('h2.example.com', 1234, 42),
+          FakeConnection.new('h0.example.com', 1234),
+          FakeConnection.new('h1.example.com', 1234),
+          FakeConnection.new('h2.example.com', 1234),
         ]
       end
 
@@ -242,7 +242,7 @@ module Cql
 
         context 'when it receives a new connection from the connection manager' do
           let :new_connection do
-            FakeConnection.new('h3.example.com', 1234, 5)
+            FakeConnection.new('h3.example.com', 1234)
           end
 
           before do

--- a/spec/support/fake_io_reactor.rb
+++ b/spec/support/fake_io_reactor.rb
@@ -26,13 +26,13 @@ class FakeIoReactor
     @before_startup_handler = handler
   end
 
-  def connect(host, port, timeout)
+  def connect(host, port, options)
     if host == '0.0.0.0'
       Cql::Future.failed(Cql::Io::ConnectionError.new('Can\'t connect to 0.0.0.0'))
     elsif @down_nodes.include?(host)
       Cql::Future.failed(Cql::Io::ConnectionError.new('Node down'))
     else
-      connection = FakeConnection.new(host, port, timeout)
+      connection = FakeConnection.new(host, port, options)
       @connections << connection
       @connection_listeners.each do |listener|
         listener.call(connection)
@@ -71,12 +71,13 @@ class FakeIoReactor
 end
 
 class FakeConnection
-  attr_reader :host, :port, :timeout, :requests, :keyspace
+  attr_reader :host, :port, :timeout, :options, :requests, :keyspace
 
-  def initialize(host, port, timeout, data={})
+  def initialize(host, port, options={}, data={})
     @host = host
     @port = port
-    @timeout = timeout
+    @options = options || {}
+    @timeout = @options[:timeout]
     @requests = []
     @responses = []
     @closed = false


### PR DESCRIPTION
This is a work in progress for #105. Most of the work is in Ione (see iconara/ione#6), the only thing that is needed in cql-rb is a way to get the `OpenSSL::SSL::SSLContext` into the connection options.

I've managed to run cql-rb against a node with client encryption enabled like this:

``` ruby
cert_path = '/Users/theo/.ccm/encrypted_206/node1/conf/server.cer'
cert_store = OpenSSL::X509::Store.new
cert_store.set_default_paths
cert_store.add_cert(OpenSSL::X509::Certificate.new(File.read(cert_path)))
ssl_context = OpenSSL::SSL::SSLContext.new
ssl_context.cert_store = cert_store
ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER

client = Cql::Client.connect(ssl: ssl_context)
client.execute("SELECT * FROM system.local")
```

You also need this in your Gemfile

``` ruby
gem 'ione', github: 'iconara/ione', branch: 'ssl_support'
```

The API is not final, maybe the option will be called something different.
