### PR TITLE
Allows TimeUuid and Uuid to be compared for equality

### DIFF
--- a/lib/cql/time_uuid.rb
+++ b/lib/cql/time_uuid.rb
@@ -18,9 +18,9 @@ module Cql
     end
 
     def <=>(other)
-      c = self.time_bits <=> other.time_bits
-      return c unless c == 0
-      (self.value & LOWER_HALF_MASK) <=> (other.value & LOWER_HALF_MASK)
+      c = self.value <=> other.value
+      return c if c == 0
+      self.time_bits <=> other.time_bits
     end
 
     protected

--- a/spec/cql/time_uuid_spec.rb
+++ b/spec/cql/time_uuid_spec.rb
@@ -32,6 +32,12 @@ module Cql
       it 'sorts by the time component' do
         uuids.shuffle.sort.should == uuids
       end
+      
+      it 'allows comparison of UUID and TimeUUID' do
+        x = generator.next
+        y = Uuid.new(x.value)
+        x.should == y
+      end
     end
   end
 


### PR DESCRIPTION
Currently, if you try to compare a Uuid and TimeUuid, there's some weirdness because of how Comparable implements ==.

[2] pry(main)> id = Cql::TimeUuid::Generator.new.next
=> #<Cql::TimeUuid:0x00000001d6fe88 @n=198073153519907614003849507369077940458>
[3] pry(main)> id2 = Cql::Uuid.new(id.value)
=> #<Cql::Uuid:0x00000001d9df40 @n=198073153519907614003849507369077940458>
[4] pry(main)> id2 == id
=> true
[5] pry(main)> id == id2
=> false

This patch reverses the order of operations allowing a Uuid and TimeUuid with the same value to be equal.
