### PR TITLE
Fixing bug with appending varint of 0.

### DIFF
--- a/lib/cql/protocol/cql_byte_buffer.rb
+++ b/lib/cql/protocol/cql_byte_buffer.rb
@@ -251,6 +251,9 @@ module Cql
       def append_varint(n)
         num = n
         bytes = []
+
+        bytes << 0 if num == 0
+
         until num == 0
           bytes << (num & 0xff)
           num = num >> 8

--- a/spec/cql/protocol/cql_byte_buffer_spec.rb
+++ b/spec/cql/protocol/cql_byte_buffer_spec.rb
@@ -810,6 +810,11 @@ module Cql
       end
 
       describe '#append_varint' do
+        it 'encodes zero' do
+          buffer.append_varint(0)
+          buffer.should eql_bytes("\x00")
+        end
+
         it 'encodes a variable length integer' do
           buffer.append_varint(1231312312331283012830129382342342412123)
           buffer.should eql_bytes("\x03\x9EV \x15\f\x03\x9DK\x18\xCDI\\$?\a[")


### PR DESCRIPTION
Our team discovered an issue with saving a BigDecimal value of "0.0". We found that the append_varint method in cql_byte_buffer.rb doesn't encode the number 0. This commit fixes append_varint, fixing the usage of BigDecimal "0.0".
