### PR TITLE
Allow mixed case keyspace names

### DIFF
--- a/lib/cql/client/keyspace_changer.rb
+++ b/lib/cql/client/keyspace_changer.rb
@@ -13,7 +13,7 @@ module Cql
       def use_keyspace(connection, keyspace)
         return Future.resolved(connection) unless keyspace
         return Future.failed(InvalidKeyspaceNameError.new(%("#{keyspace}" is not a valid keyspace name))) unless valid_keyspace_name?(keyspace)
-        request = Protocol::QueryRequest.new("USE #{keyspace}", nil, nil, :one)
+        request = Protocol::QueryRequest.new("USE \"#{keyspace}\"", nil, nil, :one)
         @request_runner.execute(connection, request).map(connection)
       end
 


### PR DESCRIPTION
Currently `use_keyspace` will only work for keyspace names which are all lower case. Quoting the argument to `USE` is a simple fix. Would be nice if a new minor version of the gem could be released if possible.
