### PR TITLE
Suppress warning "Comparable#== will no more rescue exceptions of #<=> in the next release."

### DIFF
--- a/lib/cql/time_uuid.rb
+++ b/lib/cql/time_uuid.rb
@@ -18,6 +18,7 @@ module Cql
     end
 
     def <=>(other)
+      return nil unless other.kind_of?(Cql::Uuid)
       c = self.value <=> other.value
       return c if c == 0
       self.time_bits <=> other.time_bits

--- a/spec/cql/time_uuid_spec.rb
+++ b/spec/cql/time_uuid_spec.rb
@@ -38,6 +38,12 @@ module Cql
         y = Uuid.new(x.value)
         x.should == y
       end
+
+      it 'allows comparison of TimeUUID and nil' do
+        x = generator.next
+        y = nil
+        lambda { x.should_not == y }.should_not raise_error
+      end
     end
   end
 


### PR DESCRIPTION
Hi, thank you for your nice gem.

Unfortunately, `Comparable#==` will no more rescue exception in future release.
Thus `timeuuid == nil` raises undefined method exception.
This warning shows in ruby 2.2.0-preview1.

I try to write patch for this problem.
How about this?

see also: https://bugs.ruby-lang.org/issues/7688
