### PR TITLE
Prevent starvation in case of many concurrent requests and timeouts

### DIFF
--- a/lib/cql/protocol/cql_protocol_handler.rb
+++ b/lib/cql/protocol/cql_protocol_handler.rb
@@ -202,8 +202,7 @@ module Cql
           else
             complete_request(id, @current_frame.body)
           end
-          @current_frame = @frame_decoder.decode_frame(@read_buffer)
-          flush_request_queue
+          @current_frame = @frame_decoder.decode_frame(@read_buffer)          
         end
       end
 
@@ -233,6 +232,7 @@ module Cql
         if response.is_a?(Protocol::SetKeyspaceResultResponse)
           @keyspace = response.keyspace
         end
+        flush_request_queue
         unless promise.timed_out?
           promise.fulfill(response)
         end
@@ -256,7 +256,7 @@ module Cql
             if @request_queue_out.any? && (id = next_stream_id)
               promise = @request_queue_out.shift
               if promise.timed_out?
-                id = nil
+                next
               else
                 frame = promise.frame
                 @promises[id] = promise


### PR DESCRIPTION
In case there are many concurrent requests and the callbacks for the futures create more requests, there is starvation of existing requests. If there are timeouts involved, they may be triggered because of this starvation, but this is undesired behavior even without timeouts.
Also, in case there is a timeout, the `id = nil` line in `flush_request_queue` causes it to miss out on the event, which in extreme cases make cause the system to go into a state in which there are requests waiting, but they will never be sent.
