### PR TITLE
Fix warnings when running in ruby 2.2.0

### DIFF
--- a/lib/cql/time_uuid.rb
+++ b/lib/cql/time_uuid.rb
@@ -18,8 +18,10 @@ module Cql
     end
 
     def <=>(other)
+      return unless other.respond_to? :value
       c = self.value <=> other.value
       return c if c == 0
+      return unless other.respond_to? :time_bits
       self.time_bits <=> other.time_bits
     end
 


### PR DESCRIPTION
I was getting a few warnings when using the `cequel` gem under ruby 2.2.0. I traced the warning source to be in the `TimeUuid` class in this gem.

```
/opt/boxen/rbenv/versions/2.2.0/gemsets/kuende/gems/cequel-1.5.0/lib/cequel/record/dirty.rb:59: warning: Comparable#== will no more rescue exceptions of #<=> in the next release.
/opt/boxen/rbenv/versions/2.2.0/gemsets/kuende/gems/cequel-1.5.0/lib/cequel/record/dirty.rb:59: warning: Return nil in #<=> if the comparison is inappropriate or avoid such comparison.
```

